### PR TITLE
Add injection of WP_MEMORY_LIMIT into entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ For any issues relating to this module, [raise an issue against this repo.](http
 | <a name="input_wordpress_admin_email"></a> [wordpress\_admin\_email](#input\_wordpress\_admin\_email) | The email address of the default wordpress admin user. | `string` | `"admin@example.com"` | no |
 | <a name="input_wordpress_admin_password"></a> [wordpress\_admin\_password](#input\_wordpress\_admin\_password) | The password of the default wordpress admin user. | `string` | `"techtospeech.com"` | no |
 | <a name="input_wordpress_admin_user"></a> [wordpress\_admin\_user](#input\_wordpress\_admin\_user) | The username of the default wordpress admin user. | `string` | `"supervisor"` | no |
+| <a name="input_wordpress_memory_limit"></a> [wordpress\_memory\_limit](#input\_wordpress\_memory\_limit) | The memory to allow the Wordpress process to use (in M) | `string` | `"256M"` | no |
 | <a name="input_wordpress_subdomain"></a> [wordpress\_subdomain](#input\_wordpress\_subdomain) | The subdomain used for the Wordpress container. | `string` | `"wordpress"` | no |
 ## Modules
 

--- a/ecs.tf
+++ b/ecs.tf
@@ -123,6 +123,7 @@ resource "aws_ecs_task_definition" "wordpress_container" {
     wordpress_admin_password = var.wordpress_admin_password
     wordpress_admin_email    = var.wordpress_admin_email
     site_name                = var.site_name
+    wordpress_memory_limit   = var.wordpress_memory_limit
   })
 
   runtime_platform {
@@ -225,7 +226,7 @@ resource "aws_ecs_service" "wordpress_service" {
   desired_count   = var.launch
   # iam_role =
   capacity_provider_strategy {
-    capacity_provider = var.graviton_fargate_enabled ? (contains(local.graviton_fargate_regions_unsupported, data.aws_region.current) ? "FARGATE_SPOT" : "FARGATE") : "FARGATE"
+    capacity_provider = var.graviton_fargate_enabled ? (contains(local.graviton_fargate_regions_unsupported, data.aws_region.current) ? "FARGATE_SPOT" : "FARGATE") : "FARGATE_SPOT"
     weight            = "100"
     base              = "1"
   }
@@ -248,9 +249,9 @@ resource "aws_ecs_cluster" "wordpress_cluster" {
 
 resource "aws_ecs_cluster_capacity_providers" "wordpress_cluster" {
   cluster_name       = aws_ecs_cluster.wordpress_cluster.name
-  capacity_providers = [var.graviton_fargate_enabled ? (contains(local.graviton_fargate_regions_unsupported, data.aws_region.current) ? "FARGATE_SPOT" : "FARGATE") : "FARGATE"]
+  capacity_providers = [var.graviton_fargate_enabled ? (contains(local.graviton_fargate_regions_unsupported, data.aws_region.current) ? "FARGATE_SPOT" : "FARGATE") : "FARGATE_SPOT"]
   default_capacity_provider_strategy {
-    capacity_provider = var.graviton_fargate_enabled ? (contains(local.graviton_fargate_regions_unsupported, data.aws_region.current) ? "FARGATE_SPOT" : "FARGATE") : "FARGATE"
+    capacity_provider = var.graviton_fargate_enabled ? (contains(local.graviton_fargate_regions_unsupported, data.aws_region.current) ? "FARGATE_SPOT" : "FARGATE") : "FARGATE_SPOT"
     weight            = "100"
     base              = "1"
   }

--- a/modules/codebuild/codebuild_files/docker-entrypoint.sh
+++ b/modules/codebuild/codebuild_files/docker-entrypoint.sh
@@ -318,6 +318,8 @@ fi
 if ! sudo -u www-data wp plugin is-installed wp2static-addon-s3; then
 	sudo -u www-data wp plugin install /tmp/serverless-wordpress-s3-addon.zip --activate --path=/var/www/html || true
 fi
+# Update WP_MEMORY_LIMIT
+sudo -u www-data wp config set WP_MEMORY_LIMIT ${WP_MEMORY_LIMIT}
 # # Update Wordpress options with IP of running container
 sudo -u www-data wp option update siteurl "http://${CONTAINER_DNS}" || true
 sudo -u www-data wp option update home "http://${CONTAINER_DNS}" || true

--- a/task-definitions/wordpress.json
+++ b/task-definitions/wordpress.json
@@ -14,7 +14,8 @@
         {"name": "CONTAINER_DNS_ZONE", "value": "${container_dns_zone}"},
         {"name": "WORDPRESS_ADMIN_USER", "value": "${wordpress_admin_user}"},
         {"name": "WORDPRESS_ADMIN_PASSWORD", "value": "${wordpress_admin_password}"},
-        {"name": "WORDPRESS_ADMIN_EMAIL", "value": "${wordpress_admin_email}"}
+        {"name": "WORDPRESS_ADMIN_EMAIL", "value": "${wordpress_admin_email}"},
+        {"name": "WP_MEMORY_LIMIT", "value": "${wordpress_memory_limit}"}
     ],
     "essential": true,
     "image": "${wordpress_image}",

--- a/variables.tf
+++ b/variables.tf
@@ -140,6 +140,12 @@ variable "wordpress_admin_email" {
   default     = "admin@example.com"
 }
 
+variable "wordpress_memory_limit" {
+  type        = string
+  description = "The memory to allow the Wordpress process to use (in M)"
+  default     = "256M"
+}
+
 variable "waf_acl_rules" {
   type        = list(any)
   description = "List of WAF rules to apply. Can be customized to apply others created outside of module."


### PR DESCRIPTION
Adds a variable for WP_MEMORY_LIMIT and passes it in with a default value of 256M. 

Also fixes a stupid logic bug with Graviton capacity providers. 