### PR TITLE
CloudFront Function and WP Plugin fixes

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -205,9 +205,33 @@ You may now edit Wordpress as you would normally, customize your site as you lik
 section of the WP2Static plugin, and click the 'Generate Static Site' button. This will take some minutes depending on
 the size of your site. When complete the site will be published in S3, and available via the public URL configured
 in your module definition.
-
+  cloudfront_function_301_redirects = {
+    # Old category pages
+    "^\\/(pre-historia)$": "/categoria/$1/",
 Gentle reminder that no backup options are currently bundled with this module - the most effective means would be to
 generate and retain a backup from within Wordpress for maximum flexibility. We recommend the UpdraftPlus plugin.
+
+## Permanent Redirects
+
+Basic url path based permanent redirects are supported via the CloudFront function. The variable `cloudfront_function_301_redirects` can be set with a custom map of match to destination mappings.
+
+Some aspects that need to be taken into consideration for the match:
+
+* It's a regular expression
+* Group replacements are supported
+* Runs in a Javascript function, escaping needs to be taken into consideration
+* Passed through a TF var, so escaping that needs to be taking into account as well
+
+An example to match a path like `/category-name`, a suitable match would be `"^\\/(category-name)$"`. Breaking down the `\\/` part, the first `\` tells TF to escape the second `\`, which is the Regex escape for the `/` character.
+
+An example:
+
+```
+cloudfront_function_301_redirects = {
+  # Redirects /travel to /category/travel/
+  "^\\/(travel)$": "/category/$1/",
+}
+```
 
 ## Troubleshooting
 

--- a/.header.md
+++ b/.header.md
@@ -205,9 +205,7 @@ You may now edit Wordpress as you would normally, customize your site as you lik
 section of the WP2Static plugin, and click the 'Generate Static Site' button. This will take some minutes depending on
 the size of your site. When complete the site will be published in S3, and available via the public URL configured
 in your module definition.
-  cloudfront_function_301_redirects = {
-    # Old category pages
-    "^\\/(pre-historia)$": "/categoria/$1/",
+
 Gentle reminder that no backup options are currently bundled with this module - the most effective means would be to
 generate and retain a backup from within Wordpress for maximum flexibility. We recommend the UpdraftPlus plugin.
 

--- a/main.tf
+++ b/main.tf
@@ -29,8 +29,10 @@ module "cloudfront" {
   }
   depends_on = [aws_acm_certificate_validation.wordpress_site,
   module.waf]
-  cloudfront_class = var.cloudfront_class
-  waf_acl_arn      = var.waf_enabled ? module.waf[0].waf_acl_arn : null
+  
+  cloudfront_class                  = var.cloudfront_class
+  waf_acl_arn                       = var.waf_enabled ? module.waf[0].waf_acl_arn : null
+  cloudfront_function_301_redirects = var.cloudfront_function_301_redirects
 }
 
 module "waf" {

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,8 @@ module "codebuild" {
   wordpress_ecr_repository   = aws_ecr_repository.serverless_wordpress.name
   aws_account_id             = var.aws_account_id
   container_memory           = var.ecs_memory
+  wp2static_version          = var.wp2static_version
+  wp2static_s3_addon_version = var.wp2static_s3_addon_version
 }
 
 module "cloudfront" {

--- a/modules/cloudfront/function_rewrite/index.js.tftpl
+++ b/modules/cloudfront/function_rewrite/index.js.tftpl
@@ -5,7 +5,7 @@ function handler(event) {
     try {
         %{ for match, target in REDIRECTS }
         if (/${match}/.test(uri)) {
-            return permanentRedirect(/${match}/, '${target}');
+            return permanentRedirect(uri, /${match}/, '${target}');
         }
         %{ endfor ~}
 
@@ -23,7 +23,7 @@ function handler(event) {
     return request;
 }
 
-function permanentRedirect(match, target) {
+function permanentRedirect(uri, match, target) {
     return {
         statusCode: 301,
         statusDescription: 'Moved Permanently',

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -66,7 +66,7 @@ variable "graviton_codebuild_enabled" {
 
 variable "wp2static_version" {
   type        = string
-  description = "Version of WP2Static to use from https://github.com/leonstafford/wp2static/releases"
+  description = "Version of WP2Static to use from https://github.com/WP2Static/wp2static/releases"
   default     = "7.1.7"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -156,7 +156,7 @@ variable "wordpress_memory_limit" {
 
 variable "wp2static_version" {
   type        = string
-  description = "Version of WP2Static to use from https://github.com/leonstafford/wp2static/releases"
+  description = "Version of WP2Static to use from https://github.com/WP2Static/wp2static/releases"
   default     = "7.1.7"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -154,6 +154,18 @@ variable "wordpress_memory_limit" {
   default     = "256M"
 }
 
+variable "wp2static_version" {
+  type        = string
+  description = "Version of WP2Static to use from https://github.com/leonstafford/wp2static/releases"
+  default     = "7.1.7"
+}
+
+variable "wp2static_s3_addon_version" {
+  type        = string
+  description = "Version of the WP2Static S3 Add-on to use from https://github.com/leonstafford/wp2static-addon-s3/releases/"
+  default     = "1.0"
+}
+
 variable "waf_acl_rules" {
   type        = list(any)
   description = "List of WAF rules to apply. Can be customized to apply others created outside of module."


### PR DESCRIPTION
Some fixes for things I came across while integrating the `release/0.2.0` branch:

* Adds some blurb to the README about how to use the permanent redirects var
* Passes `wp2static_version`, `wp2static_s3_addon_version` and `cloudfront_function_301_redirects` from root module to child modules
* Fixes missing `uri` param in CloudFront function
* Updates uri for `wp2static` releases page which has been recently migrated