### PR TITLE
fix: pass site_prefix to CloudFront module

### DIFF
--- a/docs/examples/vpc_setup/vpc.tf
+++ b/docs/examples/vpc_setup/vpc.tf
@@ -89,14 +89,14 @@ resource "aws_route_table" "main_private" {
 }
 
 resource "aws_route_table_association" "main_subnets_public" {
-  count          = length(data.aws_subnet_ids.main_public.ids)
-  subnet_id      = tolist(data.aws_subnet_ids.main_public.ids)[count.index]
+  count          = length(data.aws_subnet_ids.main_public) > 0 ? length(data.aws_subnet_ids.main_public) : 0
+  subnet_id      = element(aws_subnet.main_public.*.id, count.index)
   route_table_id = aws_route_table.main_public.id
 }
 
 resource "aws_route_table_association" "main_subnets_private" {
-  count          = length(data.aws_subnet_ids.main_private.ids)
-  subnet_id      = tolist(data.aws_subnet_ids.main_private.ids)[count.index]
+  count          = length(data.aws_subnet_ids.main_private) > 0 ? length(data.aws_subnet_ids.main_private) : 0
+  subnet_id      = element(aws_subnet.main_private.*.id, count.index)
   route_table_id = aws_route_table.main_private.id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ module "cloudfront" {
   source             = "./modules/cloudfront"
   site_name          = var.site_name
   site_domain        = var.site_domain
+  site_prefix        = var.site_prefix
   cloudfront_ssl     = aws_acm_certificate.wordpress_site.arn
   cloudfront_aliases = var.cloudfront_aliases
   providers = {


### PR DESCRIPTION
This PR updates `main.tf` to pass the `site_prefix` variable to the CloudFront module. The module references the site prefix when creating the Wordpress bucket: https://github.com/TechToSpeech/terraform-aws-serverless-static-wordpress/blob/abc903d9d3aabbb2fbb51e47679c0b2c61b3f6e7/modules/cloudfront/distribution.tf#L4-L5

However, `site_prefix` was not passed from the main module instantiation to the submodule. For me, this caused an error because I already had an S3 bucket with the `www.<site_domain>.com` created. `www` is the variable default defined here: https://github.com/TechToSpeech/terraform-aws-serverless-static-wordpress/blob/abc903d9d3aabbb2fbb51e47679c0b2c61b3f6e7/modules/cloudfront/variables.tf#L6-L10

```
Error creating S3 bucket: BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it.
```

By passing through the site prefix, with this PR, I was able to get past the error and create the bucket `<custom_site_prefix>.<site_domain>.com`.