### PR TITLE
fix: s3 bucket deprecated arguments

### DIFF
--- a/modules/cloudfront/distribution.tf
+++ b/modules/cloudfront/distribution.tf
@@ -4,13 +4,16 @@
 resource "aws_s3_bucket" "wordpress_bucket" {
   bucket        = "${var.site_prefix}.${var.site_domain}"
   force_destroy = true
-  server_side_encryption_configuration {
-    rule {
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "wordpress_bucket" {
+  bucket = aws_s3_bucket.wordpress_bucket.bucket
+
+  rule {
       apply_server_side_encryption_by_default {
         sse_algorithm = "AES256"
       }
     }
-  }
 }
 
 resource "aws_s3_bucket_public_access_block" "wordpress_bucket" {

--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -5,15 +5,22 @@ data "aws_region" "current" {}
 #tfsec:ignore:AWS002 #tfsec:ignore:AWS077
 resource "aws_s3_bucket" "code_source" {
   bucket        = var.codebuild_bucket
-  acl           = "private"
   force_destroy = true
-  server_side_encryption_configuration {
-    rule {
+}
+
+resource "aws_s3_bucket_acl" "code_source" {
+  bucket = aws_s3_bucket.code_source.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "code_source" {
+  bucket = aws_s3_bucket.code_source.bucket
+
+  rule {
       apply_server_side_encryption_by_default {
         sse_algorithm = "AES256"
       }
     }
-  }
 }
 
 resource "aws_s3_bucket_public_access_block" "code_source" {


### PR DESCRIPTION
This PR resolves the following deprecations for arguments to s3 buckets:

```
│ Warning: Argument is deprecated
│
│   with module.travel_blog.module.cloudfront.aws_s3_bucket.wordpress_bucket,
│   on .terraform/modules/travel_blog/modules/cloudfront/distribution.tf line 4, in resource "aws_s3_bucket" "wordpress_bucket":
│    4: resource "aws_s3_bucket" "wordpress_bucket" {
│
│ Use the aws_s3_bucket_server_side_encryption_configuration resource instead
│
│ (and 5 more similar warnings elsewhere)
```

```
│ Warning: Argument is deprecated
│
│   with module.travel_blog.module.codebuild.aws_s3_bucket.code_source,
│   on .terraform/modules/travel_blog/modules/codebuild/main.tf line 8, in resource "aws_s3_bucket" "code_source":
│    8:   acl           = "private"
│
│ Use the aws_s3_bucket_acl resource instead
│
│ (and one more similar warning elsewhere)
```