### PR TITLE
fix: use site_prefix in DNS entries

### DIFF
--- a/docs/examples/vpc_setup/vpc.tf
+++ b/docs/examples/vpc_setup/vpc.tf
@@ -89,14 +89,14 @@ resource "aws_route_table" "main_private" {
 }
 
 resource "aws_route_table_association" "main_subnets_public" {
-  count          = length(data.aws_subnet_ids.main_public.ids)
-  subnet_id      = tolist(data.aws_subnet_ids.main_public.ids)[count.index]
+  count          = length(data.aws_subnet_ids.main_public) > 0 ? length(data.aws_subnet_ids.main_public) : 0
+  subnet_id      = element(aws_subnet.main_public.*.id, count.index)
   route_table_id = aws_route_table.main_public.id
 }
 
 resource "aws_route_table_association" "main_subnets_private" {
-  count          = length(data.aws_subnet_ids.main_private.ids)
-  subnet_id      = tolist(data.aws_subnet_ids.main_private.ids)[count.index]
+  count          = length(data.aws_subnet_ids.main_private) > 0 ? length(data.aws_subnet_ids.main_private) : 0
+  subnet_id      = element(aws_subnet.main_private.*.id, count.index)
   route_table_id = aws_route_table.main_private.id
 }
 

--- a/r53.tf
+++ b/r53.tf
@@ -1,15 +1,27 @@
 resource "aws_route53_record" "www" {
+  count   = var.site_prefix == "www" ? 0 : 1
   zone_id = var.hosted_zone_id
-  name    = "www"
+  name    = "www.${var.site_prefix}.${var.site_domain}"
   type    = "CNAME"
   ttl     = "600"
-  records = [var.site_domain]
+  records = ["${var.site_prefix}${var.site_prefix == "" ? "" : "."}${var.site_domain}"]
 }
 
 resource "aws_route53_record" "apex" {
   zone_id = var.hosted_zone_id
-  name    = var.site_domain
+  name    = "${var.site_prefix}${var.site_prefix == "" ? "" : "."}${var.site_domain}"
   type    = "A"
+  alias {
+    name                   = module.cloudfront.wordpress_cloudfront_distribution_domain_name
+    zone_id                = module.cloudfront.wordpress_cloudfront_distrubtion_hostedzone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "apex_aaaa" {
+  zone_id = var.hosted_zone_id
+  name    = "${var.site_prefix}${var.site_prefix == "" ? "" : "."}${var.site_domain}"
+  type    = "AAAA"
   alias {
     name                   = module.cloudfront.wordpress_cloudfront_distribution_domain_name
     zone_id                = module.cloudfront.wordpress_cloudfront_distrubtion_hostedzone_id


### PR DESCRIPTION
Previously, the site_prefix was not taken into account when creating the DNS entries.