### PR TITLE
Fix: Use less strict version string

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -44,7 +44,7 @@ resource "aws_rds_cluster" "serverless_wordpress" {
   db_subnet_group_name                = aws_db_subnet_group.main_vpc.name
   cluster_identifier                  = "${var.site_name}-serverless-wordpress"
   engine                              = "aurora-mysql"
-  engine_version                      = "5.7.mysql_aurora.2.07.1"
+  engine_version                      = "5.7"
   engine_mode                         = "serverless"
   database_name                       = "wordpress"
   master_username                     = "wp_master"


### PR DESCRIPTION
Amazon will periodically update RDS versions behind the scenes.  By using a less string version string, you allow for these changes to happen without causing terraform drift issues.  Locking on the engine version should maintain compatibility.

This addresses https://github.com/TechToSpeech/terraform-aws-serverless-static-wordpress/issues/81