### PR TITLE
docs: add link to CDK alternative

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -223,6 +223,6 @@ For any issues relating to this module, [raise an issue against this repo.](http
 
 An alternative written for [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/v2/guide/home.html), is
 available at [`blimmer/cdk-static-wordpress`](https://github.com/blimmer/cdk-static-wordpress). Many open issues
-on this repository have been resolved in the other project. Additionally, the almost any arbitrary property on the
+on this repository have been resolved in the other project. Additionally, almost any arbitrary property on the
 infrastructure [can be customized](https://github.com/blimmer/cdk-static-wordpress#escape-hatches), allowing additional
 flexibility.

--- a/.header.md
+++ b/.header.md
@@ -218,3 +218,11 @@ If the job fails immediately and your site has previously generated a sitemaps.x
 that generates this file and the crawl job can fail fast if it cannot locate it. For all other features and issues
 relating to WP2Static, [raise an issue on their repo](https://github.com/leonstafford/wp2static/issues).
 For any issues relating to this module, [raise an issue against this repo.](https://github.com/TechToSpeech/terraform-aws-serverless-static-wordpress/issues)
+
+## Alternatives
+
+An alternative written for [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/v2/guide/home.html), is
+available at [`blimmer/cdk-static-wordpress`](https://github.com/blimmer/cdk-static-wordpress). Many open issues
+on this repository have been resolved in the other project. Additionally, the almost any arbitrary property on the
+infrastructure [can be customized](https://github.com/blimmer/cdk-static-wordpress#escape-hatches), allowing additional
+flexibility.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ that generates this file and the crawl job can fail fast if it cannot locate it.
 relating to WP2Static, [raise an issue on their repo](https://github.com/leonstafford/wp2static/issues).
 For any issues relating to this module, [raise an issue against this repo.](https://github.com/TechToSpeech/terraform-aws-serverless-static-wordpress/issues)
 
+## Alternatives
+
+An alternative written for [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/v2/guide/home.html), is
+available at [`blimmer/cdk-static-wordpress`](https://github.com/blimmer/cdk-static-wordpress). Many open issues
+on this repository have been resolved in the other project. Additionally, the almost any arbitrary property on the
+infrastructure [can be customized](https://github.com/blimmer/cdk-static-wordpress#escape-hatches), allowing additional
+flexibility.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ For any issues relating to this module, [raise an issue against this repo.](http
 
 An alternative written for [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/v2/guide/home.html), is
 available at [`blimmer/cdk-static-wordpress`](https://github.com/blimmer/cdk-static-wordpress). Many open issues
-on this repository have been resolved in the other project. Additionally, the almost any arbitrary property on the
+on this repository have been resolved in the other project. Additionally, almost any arbitrary property on the
 infrastructure [can be customized](https://github.com/blimmer/cdk-static-wordpress#escape-hatches), allowing additional
 flexibility.
 


### PR DESCRIPTION
This project has been really great and inspired my CDK translation of this repo, https://github.com/blimmer/cdk-static-wordpress. If you're open to it, I added an `alternatives` section to the README.

My project fixes at least: #80, #79, #70, #15, #19, #57, #24, #54, #51, #29, #35, #33, #31, #27, #23, #16 